### PR TITLE
maxytec-hi3798mv.inc: remove EXTRA_OECONF_append_pn-kodi

### DIFF
--- a/conf/machine/include/maxytec-hi3798mv.inc
+++ b/conf/machine/include/maxytec-hi3798mv.inc
@@ -29,9 +29,6 @@ EXTRA_OECONF_append_pn-enigma2 += " --with-alphablendingacceleration=always --wi
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 
-# Kodi
-EXTRA_OECONF_append_pn-kodi += " --with-gpu=mali --enable-player=hiplayer"
-
 # Gstreamer dvbmediasink
 DVBMEDIASINK_CONFIG = "--with-h265 --with-vb8 --with-vb9 --with-wma --with-wmv --with-pcm  --with-eac3 --with-amr --with-spark"
 


### PR DESCRIPTION
in kodi > 18 this is now unnecessary in the machine conf files, it is derived
from MACHINE_FEATURES

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>